### PR TITLE
Containerize build environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+go/
+linux-*/
+rootfs-*
+elx-pba-*

--- a/README.md
+++ b/README.md
@@ -9,12 +9,24 @@ Pre-boot authentication image for TCG Storage devices
 ```shell
 $ sudo apt install \
     gnupg2 gpgv2 flex bison build-essential libelf-dev \
-    curl libssl-dev bc zstd dosfstools gdisk mtools
+    curl libssl-dev bc zstd dosfstools fdisk gdisk mtools
 $ gpg2 --locate-keys torvalds@kernel.org gregkh@kernel.org autosigner@kernel.org
 
 # Make sure sgdisk is in the PATH
 $ PATH=$PATH:/sbin make
 ```
+
+Alternatively, use the containerized build tools:
+
+```shell
+$ docker build \
+	-t elx-pba-builder:latest \
+	-f builder.dockerfile .
+$ docker run \
+	--rm --volume ${PWD}:/src \
+	elx-pba-builder:latest
+```
+
 
 ## Testing in a VM
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Alternatively, use the containerized build tools:
 
 ```shell
 $ docker build \
-	-t elx-pba-builder:latest \
+	-t elastx.se/elx-pba-builder:latest \
 	-f builder.dockerfile .
 $ docker run \
 	--rm --volume ${PWD}:/src \
-	elx-pba-builder:latest
+	elastx.se/elx-pba-builder:latest
 ```
 
 

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,0 +1,21 @@
+FROM docker.io/library/golang:1.17.6-bullseye
+
+RUN apt-get update && \
+	apt-get install --no-install-recommends --yes \
+	gnupg2 gpgv2 flex bison build-essential libelf-dev curl \
+	libssl-dev bc zstd dosfstools fdisk gdisk mtools && \
+	apt-get clean && \
+	apt-get autoremove && \
+	rm --force --recursive /tmp/* /var/lib/apt/lists/* /var/tmp/*
+
+# Key IDs for torvalds@kernel.org, gregkh@kernel.org
+# and autosigner@kernel.org
+RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys \
+	B8868C80BA62A1FFFAF5FDA9632D3A06589DA6B1 \
+	647F28654894E3BD457199BE38DBBDC86092693E \
+	ABAF11C65A2970B130ABE3C479BE3E4300411886
+
+ENV GOPATH=/src/go
+WORKDIR /src
+
+ENTRYPOINT /usr/bin/make


### PR DESCRIPTION
This change adds a Dockerfile that can be utilized build the PBA image.
The purpose is to enable future integration with our CI/CD pipelines and
to provide a somewhat consistent/predictable environment for building.

The change also updates the README to include a missing dependency.
