### PR TITLE
Add initial version of CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,9 @@ build_and_publish_builder_image:
 
 build_pba_image:
   stage: build
-  image: $BUILDER_IMAGE
+  image:
+    name: $BUILDER_IMAGE
+    entrypoint: [""]
   script:
     - echo $PWD
     - echo $CI_BUILDS_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,10 @@ prepare_environment_and_build:
   services:
     - docker:20.10.12-dind
   script:
+    # Hack since we are using DinD and can't rely on host path mounts
+    - echo "COPY . /src" >> builder.dockerfile
     - docker build -t elastx.se/elx-pba-builder -f builder.dockerfile .
-    - docker run --rm --volume $PWD:/src elastx.se/elx-pba-builder
+    - docker run --rm elastx.se/elx-pba-builder
   artifacts:
     paths:
       - elx-pba-x86_64.img

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,17 +1,28 @@
 stages:
+  - prepare_build_environment
   - build
 
-prepare_environment_and_build:
-  stage: build
+variables:
+  BUILDER_IMAGE: quay.io/elastx/elx-pba-builder:$CI_COMMIT_REF_NAME
+
+build_and_publish_builder_image:
+  stage: prepare_build_environment
   image: docker:stable
   services:
     - docker:20.10.12-dind
   script:
-    # Hack since we are using DinD and can't rely on host path mounts
-    - echo "COPY . /src" >> builder.dockerfile
-    - docker build -t elastx.se/elx-pba-builder -f builder.dockerfile .
-    - docker run --rm elastx.se/elx-pba-builder
+    - docker build -t "$BUILDER_IMAGE" -f builder.dockerfile .
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+    - docker push $BUILDER_IMAGE
+
+build_pba_image:
+  stage: build
+  image: $BUILDER_IMAGE
+  script:
+    - GOPATH=$PWD/go make
+    - sha256sum elx-pba-x86_64.img | tee SHA256SUMS
   artifacts:
     paths:
       - elx-pba-x86_64.img
+      - SHA256SUMS
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,9 @@ build_pba_image:
   stage: build
   image: $BUILDER_IMAGE
   script:
+    - echo $PWD
+    - echo $CI_BUILDS_DIR
+    - echo $CI_PROJECT_DIR
     - GOPATH=$PWD/go make
     - sha256sum elx-pba-x86_64.img | tee SHA256SUMS
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ prepare_environment_and_build:
   services:
     - docker:20.10.12-dind
   script:
+    # Hack since we are using DinD and can't rely on volumes
+    - echo "COPY . /src" >> builder.dockerfile
     - docker build -t elastx.se/elx-pba-builder -f builder.dockerfile .
     - docker run --rm --volume $PWD:/src elastx.se/elx-pba-builder
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,6 @@ prepare_environment_and_build:
   services:
     - docker:20.10.12-dind
   script:
-    # Hack since we are using DinD and can't rely on volumes
-    - echo "COPY . /src" >> builder.dockerfile
     - docker build -t elastx.se/elx-pba-builder -f builder.dockerfile .
     - docker run --rm --volume $PWD:/src elastx.se/elx-pba-builder
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,9 +21,6 @@ build_pba_image:
     name: $BUILDER_IMAGE
     entrypoint: [""]
   script:
-    - echo $PWD
-    - echo $CI_BUILDS_DIR
-    - echo $CI_PROJECT_DIR
     - GOPATH=$PWD/go make
     - sha256sum elx-pba-x86_64.img | tee SHA256SUMS
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+stages:
+  - build
+
+prepare_environment_and_build:
+  stage: build
+  image: docker:stable
+  services:
+    - docker:20.10.12-dind
+  script:
+    - docker build -t elastx.se/elx-pba-builder -f builder.dockerfile .
+    - docker run --rm --volume $PWD:/src elastx.se/elx-pba-builder
+  artifacts:
+    paths:
+      - elx-pba-x86_64.img
+    when: always


### PR DESCRIPTION
This change adds a configuration file for GitLab CI/CD that instructs it
to build the image using the containerized build tools.

The pipeline is far from perfect and should probably automatically
upload the resulting image as a release asset, but as of now it at least
prevents very broken builds from being merged to main.
