### PR TITLE
Reboot host after unlocking instead of boot/kexec

### DIFF
--- a/cmd/pbainit/dmi.go
+++ b/cmd/pbainit/dmi.go
@@ -10,6 +10,8 @@ import (
 type DMIData struct {
 	SystemUUID            string
 	SystemSerialNumber    string
+	BaseboardManufacturer string
+	BaseboardProduct      string
 	BaseboardSerialNumber string
 	ChassisSerialNumber   string
 }
@@ -39,6 +41,8 @@ func readDMI() (*DMIData, error) {
 		if ci, ok := pt.(*smbios.ChassisInfo); ok {
 			dmi.ChassisSerialNumber = ci.SerialNumber
 		} else if bi, ok := pt.(*smbios.BaseboardInfo); ok {
+			dmi.BaseboardManufacturer = bi.Manufacturer
+			dmi.BaseboardProduct = bi.Product
 			dmi.BaseboardSerialNumber = bi.SerialNumber
 		} else if si, ok := pt.(*smbios.SystemInfo); ok {
 			dmi.SystemSerialNumber = si.SerialNumber

--- a/cmd/pbainit/main.go
+++ b/cmd/pbainit/main.go
@@ -169,7 +169,7 @@ func main() {
 		case <-time.After(5 * time.Second):
 			// pass
 		}
-		Execute("/bbin/boot")
+		Execute("/bbin/shutdown", "reboot")
 	}()
 
 	reader.ReadString('\n')

--- a/rootfs.mk
+++ b/rootfs.mk
@@ -7,6 +7,7 @@ rootfs-$(ARCH).cpio: go/bin/u-root $(wildcard cmd/*/*.go)
 				-o "$(@)" \
 				-build=gbb \
 				-initcmd pbainit \
+				boot \
 				core \
 				github.com/u-root/u-root/cmds/exp/dmidecode \
 				github.com/u-root/u-root/cmds/exp/page \

--- a/rootfs.mk
+++ b/rootfs.mk
@@ -8,7 +8,6 @@ rootfs-$(ARCH).cpio: go/bin/u-root $(wildcard cmd/*/*.go)
 				-build=gbb \
 				-initcmd pbainit \
 				core \
-				boot \
 				github.com/u-root/u-root/cmds/exp/dmidecode \
 				github.com/u-root/u-root/cmds/exp/page \
 				github.com/u-root/u-root/cmds/exp/partprobe \


### PR DESCRIPTION
This change reboots the host after successful unlocking instead of
using u-root boot, as the latter cause the boot to fail on some systems.
